### PR TITLE
Add PartSolver Wrapper to improve exception debugging

### DIFF
--- a/AdventOfCode/Solutions/ASolution.cs
+++ b/AdventOfCode/Solutions/ASolution.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -24,9 +25,9 @@ namespace AdventOfCode.Solutions
             Day = day;
             Year = year;
             Title = title;
-            _input = new Lazy<string>(() => LoadInput());
-            _part1 = new Lazy<string>(() => SolvePartOne());
-            _part2 = new Lazy<string>(() => SolvePartTwo());
+            _input = new Lazy<string>(LoadInput);
+            _part1 = new Lazy<string>(() => SolveSafely(SolvePartOne));
+            _part2 = new Lazy<string>(() => SolveSafely(SolvePartTwo));
         }
 
         public void Solve(int part = 0)
@@ -116,6 +117,25 @@ namespace AdventOfCode.Solutions
                 }
             }
             return input;
+        }
+
+        private string SolveSafely(Func<string> solver)
+        {
+            try
+            {
+                return solver();
+            }
+            catch( Exception ) {
+                if( Debugger.IsAttached )
+                {
+                    Debugger.Break();
+                    return string.Empty;
+                }
+                else
+                {
+                    throw;
+                }
+            }
         }
 
         protected abstract string SolvePartOne();

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Template project for solving Advent of Code in C#, running on [.NET 5.0](https:/
   - [Generating Previous Year's Solution Files](#generating-previous-years-solution-files)
   - [Using a Solution's Constructor](#using-a-solutions-constructor)
   - [Using .NET Core](#using-net-core)
+  - [Automatic Debugger Break On Exception](#automatic-debugger-break-on-exception)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -107,6 +108,8 @@ Simply swap out the target framework in `AdventOfCode.csproj`.
 +    <TargetFramework>netcoreapp3.1</TargetFramework>
 ```
 
+### Automatic Debugger Break On Exception
+When running your Solutions with a Debugger attached e.g. [VSCode](https://code.visualstudio.com/docs/editor/debugging) or [Visual Studio](https://docs.microsoft.com/en-us/visualstudio/debugger/quickstart-debug-with-managed?view=vs-2019) the ASolution base class will try to pause/break the debugger when there is an uncaught Exception thrown by your solution part. This allows for inspection with the debugger without having to specifically set-up additional exception handling within the debugger or your solution.
 
 ## Contributing 
 Sure! Fork the project, make your changes, and create a pull request. Submitted issues and pull requests are quite welcome.


### PR DESCRIPTION

The new wrapper will catch any exception throw by the solver and breaks the
debugger if attached, otherwise the wrapper method re-throws to crash the
program like normal.